### PR TITLE
Update devDependencies / Use SVG badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,8 @@ Released under the MIT license.
 
 
 [typescript-api]: https://github.com/jedmao/typescript-api
-[Build Status]: https://secure.travis-ci.org/jedmao/ts-compiler.png?branch=master
-[Dependency Status]: https://gemnasium.com/jedmao/ts-compiler.png
-[NPM version]: https://badge.fury.io/js/ts-compiler.png
+[Build Status]: https://secure.travis-ci.org/jedmao/ts-compiler.svg?branch=master
+[Dependency Status]: https://gemnasium.com/jedmao/ts-compiler.svg
+[NPM version]: https://badge.fury.io/js/ts-compiler.svg
 [Views]: https://sourcegraph.com/api/repos/github.com/jedmao/ts-compiler/counters/views-24h.png
 [NPM]: https://nodei.co/npm/ts-compiler.png?downloads=true

--- a/package.json
+++ b/package.json
@@ -30,11 +30,10 @@
     "chai": "~1.9.0",
     "grunt": "~0.4.2",
     "grunt-contrib-clean": "~0.5.0",
-    "grunt-contrib-watch": "~0.5.3",
-    "grunt-mocha-test": "~0.9.0",
-    "grunt-typescript": "~0.2.7",
-    "mocha": "~1.17.0",
-    "sinon": "~1.8.2",
+    "grunt-contrib-watch": "~0.6.1",
+    "grunt-mocha-test": "~0.11.0",
+    "grunt-typescript": "~0.3.7",
+    "sinon": "~1.10.2",
     "sinon-chai": "~2.5.0"
   },
   "engines": {


### PR DESCRIPTION
- I updated devDependencies.
  - [grunt-mocha-test](https://github.com/pghalliday/grunt-mocha-test) now uses the latest version of [mocha](https://www.npmjs.org/package/mocha), so we don't need to add `mocha` module to `devDependencies` explicitly.
- I changed the image format of the badges from PNG to SVG. SVG badges look beautiful on retina displays.
